### PR TITLE
Fix room_name of invite message

### DIFF
--- a/lib/xrc/messages/invite.rb
+++ b/lib/xrc/messages/invite.rb
@@ -2,7 +2,7 @@ module Xrc
   module Messages
     class Invite < Base
       def room_name
-        @element["name/text()"].to_s
+        @element.elements["//name/text()"].to_s
       end
     end
   end


### PR DESCRIPTION
XPath location for room name seems wrong.  (small mistake also fixed)

I showed the example invitation response from on-premise edition of HipChat below.
According to xml namespace, specification rule for room name may vary from product to product.
(I don't know the specification of XMPP bridge of Slack.)

``` xml
<message from='ROOM_JID' to='USER_JID'>
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <invite from='INVITOR_JID'>
      <reason>REASON</reason>
    </invite>
  </x>
  <x xmlns='http://hipchat.com/protocol/muc#room'>
    <name>ROOM_NAME</name>
    <topic>ROOM_TOPIC</topic>
    <privacy>public</privacy>
  </x>
</message>
```
