### PR TITLE
Fix ruboty-slack clash

### DIFF
--- a/lib/xrc/parser.rb
+++ b/lib/xrc/parser.rb
@@ -37,6 +37,7 @@ module Xrc
 
     def characters(text)
       if current
+        text = text.gsub(/(?!\n)[[:cntrl:]]/, "")
         text = REXML::Text.new(text, current.whitespace, nil, true)
         current.add(text)
       end

--- a/lib/xrc/parser.rb
+++ b/lib/xrc/parser.rb
@@ -37,10 +37,20 @@ module Xrc
 
     def characters(text)
       if current
-        text = text.gsub(/(?!\n)[[:cntrl:]]/, "")
-        text = REXML::Text.new(text, current.whitespace, nil, true)
+        text = REXML::Text.new(to_safe(text), current.whitespace, nil, true)
         current.add(text)
       end
+    end
+
+    def to_safe(text)
+      text.chars.map do |c|
+        case c.ord
+        when *REXML::Text::VALID_CHAR
+          c
+        else
+          ""
+        end
+      end.join
     end
 
     def end_document


### PR DESCRIPTION
ruboty-slackを使っている時、メッセージに制御文字が含まれるとクラッシュするので直してみました。
`ほ^Bげ`のような簡単なメッセージで再現すると思います。

```
Mar 22 03:52:44 doramichan-ruboty app/bot.1:  /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/text.rb:138:in `block in check': Illegal character "\b" in raw string "ほげ" (RuntimeError) 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/text.rb:134:in `each' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/text.rb:134:in `check' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/text.rb:120:in `initialize' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/parser.rb:46:in `new' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/parser.rb:46:in `characters' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/parser.rb:28:in `block (2 levels) in bind' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/parsers/sax2parser.rb:194:in `call' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/parsers/sax2parser.rb:194:in `block in handle' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/parsers/sax2parser.rb:194:in `each' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/parsers/sax2parser.rb:194:in `handle' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/parsers/sax2parser.rb:177:in `parse' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/connection.rb:38:in `parse' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/connection.rb:34:in `start' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/connection.rb:19:in `encrypt' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/client.rb:271:in `on_tls_proceeded' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/client.rb:178:in `on_received' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/client.rb:217:in `block in connection' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/parser.rb:84:in `call' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/parser.rb:84:in `consume' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/parser.rb:55:in `end_element' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/parser.rb:28:in `block (2 levels) in bind' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/parsers/sax2parser.rb:142:in `call' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/parsers/sax2parser.rb:142:in `block in parse' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/parsers/sax2parser.rb:142:in `each' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/ruby-2.2.1/lib/ruby/2.2.0/rexml/parsers/sax2parser.rb:142:in `parse' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/connection.rb:38:in `parse' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/connection.rb:34:in `start' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/connection.rb:14:in `connect' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/xrc-6bf94202fc9e/lib/xrc/client.rb:24:in `connect' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/ruboty-slack-3a1a9edacc4f/lib/ruboty/adapters/slack.rb:87:in `connect' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bundler/gems/ruboty-slack-3a1a9edacc4f/lib/ruboty/adapters/slack.rb:14:in `run' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/gems/ruboty-1.2.1/lib/ruboty/robot.rb:54:in `adapt' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/gems/ruboty-1.2.1/lib/ruboty/robot.rb:22:in `run' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/gems/ruboty-1.2.1/lib/ruboty/commands/run.rb:5:in `call' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/gems/ruboty-1.2.1/bin/ruboty:6:in `<top (required)>' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bin/ruboty:23:in `load' 
Mar 22 03:52:44 doramichan-ruboty app/bot.1:    from /app/vendor/bundle/ruby/2.2.0/bin/ruboty:23:in `<main>' 
```

https://github.com/r7kamura/xrc/blob/v0.1.4/lib/xrc/parser.rb#L40 の行だけでも再現しました。

```
irb(main):006:0> REXML::Text.new("ほ^Bげ", false, nil, true)
RuntimeError: Illegal character "\u0002" in raw string "ほげ"
        from /Users/masutaka/.rbenv/versions/2.2.1/lib/ruby/2.2.0/rexml/text.rb:138:in `block in check'
        from /Users/masutaka/.rbenv/versions/2.2.1/lib/ruby/2.2.0/rexml/text.rb:134:in `each'
        from /Users/masutaka/.rbenv/versions/2.2.1/lib/ruby/2.2.0/rexml/text.rb:134:in `check'
        from /Users/masutaka/.rbenv/versions/2.2.1/lib/ruby/2.2.0/rexml/text.rb:120:in `initialize'
        from (irb):6:in `new'
        from (irb):6
        from /Users/masutaka/.rbenv/versions/2.2.1/bin/irb:11:in `<main>'
```

制御文字をがっつり削除することに引っかかりを感じますが、落ちるよりマシかなあと...。
